### PR TITLE
42 list ontologies

### DIFF
--- a/test/test_ontology.py
+++ b/test/test_ontology.py
@@ -90,6 +90,14 @@ class TestOntology(unittest.TestCase):
         with self.assertRaises(LookupError):
             uri = o.foobar
 
+    def test_get_ontologies(self):
+       self.assertEqual(tyto.Ontobee.get_ontologies()\
+                        ['http://purl.obolibrary.org/obo/gno.owl'],
+                        'Echinoderm Anatomy and Development Ontology')
+       self.assertEqual(tyto.EBIOntologyLookupService.get_ontologies()
+                        ['http://purl.obolibrary.org/obo/gno.owl'],
+                        'gno')
+
 class TestOLS(unittest.TestCase):
 
     SO_endpoints = SO.endpoints

--- a/tyto/endpoint/endpoint.py
+++ b/tyto/endpoint/endpoint.py
@@ -147,15 +147,6 @@ class SPARQLBuilder():
 
     def get_ontologies(self):
         query = '''
-  PREFIX owl: <http://www.w3.org/2002/07/owl#>
-  {from_clause}
-  SELECT DISTINCT ?p, ?o
-  FROM <http://purl.obolibrary.org/obo/merged/OAE>
-  WHERE{{
-    ?s a owl:Ontology .
-	?s ?p ?o .}}
-'''
-        query = '''
             SELECT distinct ?ontology_uri ?title
             {from_clause}
             WHERE
@@ -399,6 +390,10 @@ class EBIOntologyLookupServiceAPI(RESTEndpoint):
         ancestor_uri = ontology._reverse_sanitize_uri(ancestor_uri)
         return ancestor_uri in self.get_ancestors(ontology, descendant_uri)
 
+    def get_ontologies(self):
+        if not self.ontology_short_ids:
+            self._load_ontology_ids()
+        return self.ontology_short_ids
 
     def convert(self, response):
         pass


### PR DESCRIPTION
- Adds `get_ontologies()` methods for the EBI and Ontobee services, which returns a dictionary containing all the ontologies hosted at the respective endpoint.
- Resolve #42 