### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -6,7 +6,6 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 
@@ -26,7 +25,7 @@ jobs:
       matrix:
         # Default builds are on Ubuntu
         os: [ubuntu-latest]
-        python-version: [3.7, 3.9, 3.11]
+        python-version: [3.9, "3.10", 3.11, 3.12, 3.13, pypy-3.10]
         include:
           # Also test on macOS and Windows using latest Python 3
           - os: macos-latest

--- a/test/test_ontology.py
+++ b/test/test_ontology.py
@@ -22,7 +22,6 @@ class TestOntology(unittest.TestCase):
         term_c = SO.deletion
         self.assertEqual(term_c, 'https://identifiers.org/SO:0000159')
 
-    @unittest.expectedFailure
     def test_getitem(self):
         # For terms with special characters, we must use subscripting
         # rather than dynamic attributes for ontology terms
@@ -69,7 +68,6 @@ class TestOntology(unittest.TestCase):
         self.assertEqual(OM.get_term_by_uri('http://www.ontology-of-units-of-measure.org/resource/om-2/hour'),
                          'hour')
 
-    @unittest.expectedFailure
     def test_child_of(self):
         self.assertTrue(type(SO.promoter) is URI)
         self.assertTrue(SO.inducible_promoter.is_child_of(SO.promoter))
@@ -98,7 +96,6 @@ class TestOntology(unittest.TestCase):
         with self.assertRaises(LookupError):
             uri = o.foobar
 
-    @unittest.expectedFailure
     def test_get_ontologies(self):
        self.assertEqual(tyto.Ontobee.get_ontologies()\
                         ['http://purl.obolibrary.org/obo/ecao.owl'],
@@ -149,7 +146,6 @@ class TestOLS(unittest.TestCase):
         SBO.endpoints = TestOLS.SBO_endpoints
         SBO.graph = TestOLS.SBO_graph
 
-    @unittest.expectedFailure
     def test_SO(self):
         uri = 'https://identifiers.org/SO:0000167'
         self.assertEqual(SO.get_term_by_uri(uri), 'promoter')
@@ -160,13 +156,11 @@ class TestOLS(unittest.TestCase):
         with self.assertRaises(LookupError):
             self.assertIsNone(SO.foo)
 
-    @unittest.expectedFailure
     def test_parents(self):
         self.assertCountEqual(EBIOntologyLookupService.get_parents(SO, SO.inducible_promoter),
                               [SO.promoter])
         self.assertTrue(SO.inducible_promoter.is_child_of(SO.promoter))
 
-    @unittest.expectedFailure
     def test_children(self):
         children = EBIOntologyLookupService.get_children(SO, SO.promoter) 
         self.assertIn(SO.inducible_promoter, children)
@@ -174,17 +168,14 @@ class TestOLS(unittest.TestCase):
         self.assertEqual(len(children), 7)
         self.assertTrue(SO.promoter.is_parent_of(SO.inducible_promoter))
 
-    @unittest.expectedFailure
     def test_descendants(self):
         descendants = EBIOntologyLookupService.get_descendants(SO, SO.promoter) 
         self.assertIn(SO.RNApol_III_promoter, descendants)
 
-    @unittest.expectedFailure
     def test_ancestors(self):
         ancestors = EBIOntologyLookupService.get_ancestors(NCBITaxon, NCBITaxon.Escherichia_coli)
         self.assertIn(NCBITaxon.Bacteria, ancestors)
 
-    @unittest.expectedFailure
     def test_SBO(self):
         uri = 'https://identifiers.org/SBO:0000241'
         self.assertEqual(SBO.get_term_by_uri(uri), 'functional entity')

--- a/tyto/endpoint/endpoint.py
+++ b/tyto/endpoint/endpoint.py
@@ -337,18 +337,18 @@ class OntobeeEndpoint(SPARQLEndpoint):
 class EBIOntologyLookupServiceAPI(RESTEndpoint):
 
     def __init__(self):
-        super().__init__('http://www.ebi.ac.uk/ols/api/')
+        super().__init__('https://www.ebi.ac.uk/ols4/api')
         self.ontology_short_ids = {}  # Set by the _load_ontology method
 
     def _load_ontology_ids(self):
-        response = requests.get(f'{self.url}/ontologies?size=1')
+        response = requests.get(f'{self.url}/v2/ontologies?size=1')
         response = response.json()
-        total_ontologies = response['page']['totalElements']
-        response = requests.get(f'{self.url}/ontologies?size={total_ontologies}')
+        total_ontologies = response['totalElements']
+        response = requests.get(f'{self.url}/v2/ontologies?size={total_ontologies}')
         response = response.json()
-        for o in response['_embedded']['ontologies']:
+        for o in response['elements']:
             short_id = o['ontologyId']
-            iri = o['config']['id']
+            iri = o['iri']
             self.ontology_short_ids[iri] = short_id
 
     def _get_request(self, ontology: "Ontology", get_request: str):

--- a/tyto/endpoint/endpoint.py
+++ b/tyto/endpoint/endpoint.py
@@ -337,7 +337,7 @@ class OntobeeEndpoint(SPARQLEndpoint):
 class EBIOntologyLookupServiceAPI(RESTEndpoint):
 
     def __init__(self):
-        super().__init__('http://www.ebi.ac.uk/ols/api')
+        super().__init__('http://www.ebi.ac.uk/ols/api/')
         self.ontology_short_ids = {}  # Set by the _load_ontology method
 
     def _load_ontology_ids(self):
@@ -490,9 +490,9 @@ class PUG_REST(RESTEndpoint):
         raise urllib.error.HTTPError(get_query, response.status_code, response.reason, response.headers, None)
 
     def get_uri_by_term(self, ontology: "Ontology", term: str):
-        term = urllib.parse.quote(term)
-        get_query = f'https://pubchem.ncbi.nlm.nih.gov/rest/pug/substance/name/{term}/sids/JSON'
-        response = requests.get(get_query)
+        # Relevant: https://pubchem.ncbi.nlm.nih.gov/docs/pug-rest-tutorial#section=Special-Characters-in-the-URL
+        get_query = f'https://pubchem.ncbi.nlm.nih.gov/rest/pug/substance/name/sids/JSON'
+        response = requests.get(get_query, params={'name': term})
         if response.status_code == 200:
             response = response.json()
             if not response:


### PR DESCRIPTION
- Run CI matrix on currently supported Python versions 3.9-3.13. Deprecate 3.7-3.8.
- Fixes 404 error when looking up Pubchem IDs by substance name
- Upgrades EBI endpoint to latest API, and removes tests previously marked as "expected failures".
