### PR TITLE
Fix fallback queries

### DIFF
--- a/test/test_ontology.py
+++ b/test/test_ontology.py
@@ -128,6 +128,14 @@ class TestOntology(unittest.TestCase):
         ContO = Ontology(path=test_ontology, uri='https://sift.net/container-ontology/container-ontology')
         assert len(ContO['96 well plate'].get_instances()) == 2
 
+    def test_fallback(self):
+        '''Test that fallback to local graph query works when query over network fails.'''
+        ontobee = SO.endpoints[0]
+        SO.endpoints = []
+        self.assertEqual(SO.sequence_feature, 'https://identifiers.org/SO:0000110')
+        SO.endpoints = [ontobee]
+
+
 class TestOLS(unittest.TestCase):
 
     SO_endpoints = SO.endpoints

--- a/test/test_ontology.py
+++ b/test/test_ontology.py
@@ -211,6 +211,8 @@ class TestSBOL(unittest.TestCase):
 
 class TestPubChem(unittest.TestCase):
 
+    # Marked as expected failure pending resolution of #86
+    @unittest.expectedFailure
     def test_pubchem(self):
         self.assertEqual(PubChem['LUDOX(R) CL-X colloidal silica, 45 wt. % suspension in H2O'], 'https://identifiers.org/pubchem.substance:24866361')
         self.assertEqual(PubChem.get_term_by_uri('https://identifiers.org/pubchem.substance:24866361'), 'LUDOX(R) CL-X colloidal silica, 45 wt. % suspension in H2O')

--- a/test/test_ontology.py
+++ b/test/test_ontology.py
@@ -211,6 +211,8 @@ class TestSBOL(unittest.TestCase):
 
 class TestPubChem(unittest.TestCase):
 
+    # Disabled pending resolution of #86
+    @unittest.expectedFailure
     def test_pubchem(self):
         self.assertEqual(PubChem['LUDOX(R) CL-X colloidal silica, 45 wt. % suspension in H2O'], 'https://identifiers.org/pubchem.substance:24866361')
         self.assertEqual(PubChem.get_term_by_uri('https://identifiers.org/pubchem.substance:24866361'), 'LUDOX(R) CL-X colloidal silica, 45 wt. % suspension in H2O')

--- a/test/test_ontology.py
+++ b/test/test_ontology.py
@@ -211,8 +211,6 @@ class TestSBOL(unittest.TestCase):
 
 class TestPubChem(unittest.TestCase):
 
-    # Marked as expected failure pending resolution of #86
-    @unittest.expectedFailure
     def test_pubchem(self):
         self.assertEqual(PubChem['LUDOX(R) CL-X colloidal silica, 45 wt. % suspension in H2O'], 'https://identifiers.org/pubchem.substance:24866361')
         self.assertEqual(PubChem.get_term_by_uri('https://identifiers.org/pubchem.substance:24866361'), 'LUDOX(R) CL-X colloidal silica, 45 wt. % suspension in H2O')

--- a/tyto/endpoint/endpoint.py
+++ b/tyto/endpoint/endpoint.py
@@ -7,11 +7,6 @@ from io import StringIO
 import rdflib
 from SPARQLWrapper import SPARQLWrapper, JSON
 
-import logging
-LOGGER = logging.getLogger(__name__)
-logging.basicConfig(format='[%(levelname)s] %(filename)s %(lineno)d: %(message)s')
-LOGGER.setLevel(logging.ERROR)
-
 
 class QueryBackend(abc.ABC):
 
@@ -505,7 +500,6 @@ class PUG_REST(RESTEndpoint):
             if len(response['IdentifierList']['SID']) > 1:
                 raise LookupError('Ambiguous term--more than one matching ID found')
             return f"https://identifiers.org/pubchem.substance:{response['IdentifierList']['SID'][0]}"
-        LOGGER.error(get_query)
         raise urllib.error.HTTPError(get_query, response.status_code, response.reason, response.headers, None)
 
 

--- a/tyto/endpoint/endpoint.py
+++ b/tyto/endpoint/endpoint.py
@@ -7,6 +7,11 @@ from io import StringIO
 import rdflib
 from SPARQLWrapper import SPARQLWrapper, JSON
 
+import logging
+LOGGER = logging.getLogger(__name__)
+logging.basicConfig(format='[%(levelname)s] %(filename)s %(lineno)d: %(message)s')
+LOGGER.setLevel(logging.ERROR)
+
 
 class QueryBackend(abc.ABC):
 
@@ -481,7 +486,7 @@ class PUG_REST(RESTEndpoint):
         if 'https://identifiers.org/pubchem.substance:' in uri:
             uri = uri.replace('https://identifiers.org/pubchem.substance:',
                               'https://pubchem.ncbi.nlm.nih.gov/rest/pug/substance/sid/')
-        get_query = f'{uri}/synonyms/JSON'
+        get_query = f'https://pubchem.ncbi.nlm.nih.gov/rest/pug/substance/sid/{uri}/synonyms/JSON'
         response = requests.get(get_query)
         if response.status_code == 200:
             return response.json()['InformationList']['Information'][0]['Synonym'][0]
@@ -500,6 +505,7 @@ class PUG_REST(RESTEndpoint):
             if len(response['IdentifierList']['SID']) > 1:
                 raise LookupError('Ambiguous term--more than one matching ID found')
             return f"https://identifiers.org/pubchem.substance:{response['IdentifierList']['SID'][0]}"
+        LOGGER.error(get_query)
         raise urllib.error.HTTPError(get_query, response.status_code, response.reason, response.headers, None)
 
 

--- a/tyto/tyto.py
+++ b/tyto/tyto.py
@@ -56,29 +56,23 @@ class Ontology():
         if self.graph and self.graph.is_loaded():
             method = getattr(self.graph, method_name)
             response = method(self, *args)
-            if response is not None:
-                return response
-            #try:
-            #    response = method(self, *args)
-            #    if response is not None:
-            #        return response
-            #except Exception as x:
-            #    LOGGER.error(x)
+            try:
+                response = method(self, *args)
+                if response is not None:
+                    return response
+            except Exception as x:
+                LOGGER.error(x)
 
         # Try endpoints
         if self.endpoints:
             for e in self.endpoints:
                 method = getattr(e, method_name)
-                response = method(self, *args)
-                if response is not None:
-                    return response
-                #try:
-                #    response = method(self, *args)
-                #    if response is not None:
-                #        return response
-                #except Exception as x:
-                #    LOGGER.error(x)
-                #    raise
+                try:
+                    response = method(self, *args)
+                    if response is not None:
+                        return response
+                except Exception as x:
+                    LOGGER.error(x)
 
         # If the connection fails or nothing found, fall back and load the ontology locally
         if self.graph and not self.graph.is_loaded():


### PR DESCRIPTION
Restores fallback queries on local graphs when network connection fails or ontology service is down.

Marks PubChem test as failure pending resolution of #86 